### PR TITLE
Add success redirect route

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,11 @@ def save_row_to_sheet(values: list[str], sheet_name: str):
 async def menu(request: Request):
     return templates.TemplateResponse("menu.html", {"request": request})
 
+# Página de confirmación (GET)
+@app.get("/success")
+async def success(request: Request):
+    return templates.TemplateResponse("success.html", {"request": request})
+
 # 2) PRECHECK (operador)
 @app.get("/precheck")
 async def precheck_form(request: Request):
@@ -140,7 +145,7 @@ async def submit_precheck(request: Request, photos: list[UploadFile] = File(None
     row.append(" | ".join(urls))
 
     save_row_to_sheet(row, "Precheck")
-    return templates.TemplateResponse("success.html", {"request": request})
+    return RedirectResponse("/success")
 
 
 # Supervisor: formulario GET
@@ -192,7 +197,7 @@ async def submit_supervisor(request: Request, photos: list[UploadFile] = File(No
     row.append(" | ".join(urls))
 
     save_row_to_sheet(row, "Supervisor")
-    return templates.TemplateResponse("success.html", {"request": request})
+    return RedirectResponse("/success")
 
 # 4) MANTENIMIENTO
 @app.get("/mantenimiento")
@@ -248,7 +253,7 @@ async def submit_mantenimiento(request: Request, photos: list[UploadFile] = File
     row.append(" | ".join(urls))
 
     save_row_to_sheet(row, "Mantenimiento")
-    return templates.TemplateResponse("success.html", {"request": request})
+    return RedirectResponse("/success")
 
 
 


### PR DESCRIPTION
## Summary
- add dedicated /success route
- redirect POST form handlers to /success after saving

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684521f66718832990d2331a38b4e66d