### PR TITLE
Improve error handling on sheet updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,13 +88,21 @@ MAINTENANCE_ITEMS = [
     ("limpieza_radiador",   "Limpieza de radiador/intercooler",            ["Completo", "Pendiente"])
 ]
 
-def save_row_to_sheet(values: list[str], sheet_name: str):
-    sheet_service.values().append(
-        spreadsheetId=SPREADSHEET_ID,
-        range=f"{sheet_name}!A1",
-        valueInputOption="USER_ENTERED",
-        body={"values": [values]}
-    ).execute()
+def save_row_to_sheet(values: list[str], sheet_name: str) -> str | None:
+    """Append a row to the given sheet.
+
+    Returns ``None`` on success or a string with an error message on failure."""
+    try:
+        sheet_service.values().append(
+            spreadsheetId=SPREADSHEET_ID,
+            range=f"{sheet_name}!A1",
+            valueInputOption="USER_ENTERED",
+            body={"values": [values]}
+        ).execute()
+        return None
+    except Exception:
+        logger.exception("Failed to save row to sheet %s", sheet_name)
+        return "No se pudo registrar la respuesta. Intenta nuevamente."
 
 # 1) Menú principal
 @app.get("/")
@@ -139,7 +147,12 @@ async def submit_precheck(request: Request, photos: list[UploadFile] = File(None
                 urls.append(f"{base}/uploads/{fname}")
     row.append(" | ".join(urls))
 
-    save_row_to_sheet(row, "Precheck")
+    error_message = save_row_to_sheet(row, "Precheck")
+    if error_message:
+        return templates.TemplateResponse(
+            "error.html",
+            {"request": request, "message": error_message},
+        )
     return templates.TemplateResponse("success.html", {"request": request})
 
 
@@ -191,7 +204,12 @@ async def submit_supervisor(request: Request, photos: list[UploadFile] = File(No
                 urls.append(f"{base}/uploads/{filename}")
     row.append(" | ".join(urls))
 
-    save_row_to_sheet(row, "Supervisor")
+    error_message = save_row_to_sheet(row, "Supervisor")
+    if error_message:
+        return templates.TemplateResponse(
+            "error.html",
+            {"request": request, "message": error_message},
+        )
     return templates.TemplateResponse("success.html", {"request": request})
 
 # 4) MANTENIMIENTO
@@ -247,7 +265,12 @@ async def submit_mantenimiento(request: Request, photos: list[UploadFile] = File
                 urls.append(f"{base}/uploads/{fname}")
     row.append(" | ".join(urls))
 
-    save_row_to_sheet(row, "Mantenimiento")
+    error_message = save_row_to_sheet(row, "Mantenimiento")
+    if error_message:
+        return templates.TemplateResponse(
+            "error.html",
+            {"request": request, "message": error_message},
+        )
     return templates.TemplateResponse("success.html", {"request": request})
 
 

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,23 @@
+<!-- templates/error.html -->
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Error</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet" />
+</head>
+<body class="bg-red-50 flex items-center justify-center min-h-screen p-4">
+  <div class="bg-white p-8 rounded-lg shadow-lg text-center max-w-sm w-full">
+    <!-- Ícono de error -->
+    <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto mb-4 h-16 w-16 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.054 0 1.658-1.14 1.105-2.055L13.105 4.055c-.527-.864-1.683-.864-2.21 0L3.977 16.945c-.553.915.051 2.055 1.105 2.055z" />
+    </svg>
+    <h1 class="text-2xl font-semibold mb-2">Ocurrió un error</h1>
+    <p class="text-gray-700 mb-6">{{ message }}</p>
+    <a href="/" class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-lg">
+      Volver al menú de formularios
+    </a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add error page template
- log failures in `save_row_to_sheet`
- show error page when saving to Google Sheets fails
- return error message from `save_row_to_sheet` for callers

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684521fc3a6c8329a6295ce3ca1e24f9