### PR TITLE
Fix video page preview

### DIFF
--- a/templates/videos.html
+++ b/templates/videos.html
@@ -12,7 +12,7 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       {% for video in videos %}
         <div class="flex flex-col items-center">
-          <video controls class="w-full rounded shadow-lg mb-2">
+          <video controls preload="metadata" class="w-full rounded shadow-lg mb-2">
             <source src="{{ url_for('videos_static', path=video) }}" type="video/{{ video.split('.')[-1] }}">
             Tu navegador no soporta este tipo de video.
           </video>


### PR DESCRIPTION
## Summary
- make videos load metadata to show a preview thumbnail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684670398cc0832994ede5bd9b75e7c8